### PR TITLE
Clean up UI, remove extra whitespace, add comma delimiting to results

### DIFF
--- a/paye-calculator/src/UI/Algeria.js
+++ b/paye-calculator/src/UI/Algeria.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-
+import { formatNumber } from "../utils";
 import getCurrency from "../lib/utils";
 
 function AlgeriaUI({ country }) {
@@ -81,11 +81,12 @@ function AlgeriaUI({ country }) {
                     <label for="gross_pay">Gross Pay:</label>
                     <div class="input">
                       <input
-                        type="number"
+                        type="text"
                         name="gross_pay"
                         id="gross_pay"
                         value={income}
                         class="input"
+                        onFocus={(e) => e.target.value === "0" && setIncome("")}
                         onChange={(e) => setIncome(e.target.value)}
                       />
                     </div>
@@ -115,25 +116,25 @@ function AlgeriaUI({ country }) {
                   <p>
                     <label>Gross Pay:</label>
                   </p>
-                  <h4 id="output-value">{grossPay.toFixed(2)}</h4>
+                  <h4 id="output-value">{formatNumber(grossPay.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>Social Security-Employee:</label>
                   </p>
-                  <h4 id="social-security-value">{socialSecurity.toFixed(2)}</h4>
+                  <h4 id="social-security-value">{formatNumber(socialSecurity.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>PAYE:</label>
                   </p>
-                  <h4 id="paye-value">{paye.toFixed(2)}</h4>
+                  <h4 id="paye-value">{formatNumber(paye.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>Net Pay:</label>
                   </p>
-                  <h4 id="net-pay-value">{netPay.toFixed(2)}</h4>
+                  <h4 id="net-pay-value">{formatNumber(netPay.toFixed(2))}</h4>
                 </div>
               </div>
             </div>

--- a/paye-calculator/src/UI/Angola.js
+++ b/paye-calculator/src/UI/Angola.js
@@ -134,7 +134,7 @@ function AngolaUI({ country }) {
 
   return (
     <div>
-      <body>
+      <div>
         <div class="card">
           <div class="card-container">
             <div class="inputs-section">
@@ -157,11 +157,12 @@ function AngolaUI({ country }) {
                   <label>Gross Pay:</label>
                   <div class="input">
                     <input
-                      type="number"
+                      type="text"
                       name="gross_pay"
                       id="gross_pay"
                       value={income}
                       class="input"
+                      onFocus={(e) => e.target.value === "0" && setIncome("")}
                       onChange={(e) => setIncome(e.target.value)}
                     />
                   </div>
@@ -220,7 +221,7 @@ function AngolaUI({ country }) {
             </div>
           </div>
         </div>
-      </body>
+      </div>
     </div>
   );
 }

--- a/paye-calculator/src/UI/Benin.js
+++ b/paye-calculator/src/UI/Benin.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-
+import { formatNumber } from "../utils";
 import getCurrency from "../lib/utils";
 
 function BeninUI({ country }) {
@@ -56,7 +56,7 @@ function BeninUI({ country }) {
   
     return (
       <div>
-        <body>
+        <div>
           <div class="card">
             <div class="card-container">
               <div class="inputs-section">
@@ -79,11 +79,12 @@ function BeninUI({ country }) {
                     <label for="gross_pay">Gross Pay:</label>
                     <div class="input">
                       <input
-                        type="number"
+                        type="text"
                         name="gross_pay"
                         id="gross_pay"
                         value={income}
                         class="input"
+                        onFocus={(e) => e.target.value === "0" && setIncome("")}
                         onChange={(e) => setIncome(e.target.value)}
                       />
                     </div>
@@ -113,30 +114,30 @@ function BeninUI({ country }) {
                   <p>
                     <label>Gross Pay:</label>
                   </p>
-                  <h4 id="gross-pay-value">{grossPay.toFixed(2)}</h4>
+                  <h4 id="gross-pay-value">{formatNumber(grossPay.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>Social Security-Employee (CNSS):</label>
                   </p>
-                  <h4 id="social-security-value">{socialSecurity.toFixed(2)}</h4>
+                  <h4 id="social-security-value">{formatNumber(socialSecurity.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>PAYE:</label>
                   </p>
-                  <h4 id="paye-value">{paye.toFixed(2)}</h4>
+                  <h4 id="paye-value">{formatNumber(paye.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>Net Pay:</label>
                   </p>
-                  <h4 id="net-pay-value">{netPay.toFixed(2)}</h4>
+                  <h4 id="net-pay-value">{formatNumber(netPay.toFixed(2))}</h4>
                 </div>
               </div>
             </div>
           </div>
-        </body>
+        </div>
       </div>
     );
 }

--- a/paye-calculator/src/UI/Botswana.js
+++ b/paye-calculator/src/UI/Botswana.js
@@ -45,7 +45,7 @@ function BotswanaUI({ country }) {
   
   return (
     <div>
-      <body>
+      <div>
         <div class="card">
           <div class="card-container">
             <div class="inputs-section">
@@ -68,11 +68,12 @@ function BotswanaUI({ country }) {
               <label>Gross Pay:</label>
               <div class="input">
               <input
-                type="number"
+                type="text"
                 name="gross_pay"
                 id="gross_pay"
                 value={income}
                 class="input"
+                onFocus={(e) => e.target.value === "0" && setIncome("")}
                 onChange={(e) => setIncome(e.target.value)}
               />
               </div>
@@ -113,7 +114,7 @@ function BotswanaUI({ country }) {
             </div>
           </div>
         </div>
-      </body>      
+      </div>      
     </div>
   );
 }

--- a/paye-calculator/src/UI/BurkinaFaso.js
+++ b/paye-calculator/src/UI/BurkinaFaso.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-
+import { formatNumber } from "../utils";
 import getCurrency from "../lib/utils";
 
 function BurkinaFasoUI({ country }) {
@@ -61,7 +61,7 @@ function BurkinaFasoUI({ country }) {
   
     return (
       <div>
-        <body>
+        <div>
           <div class="card">
             <div class="card-container">
               <div class="inputs-section">
@@ -84,11 +84,12 @@ function BurkinaFasoUI({ country }) {
                     <label for="gross_pay">Gross Pay:</label>
                     <div class="input">
                       <input
-                        type="number"
+                        type="text"
                         name="gross_pay"
                         id="gross_pay"
                         value={income}
                         class="input"
+                        onFocus={(e) => e.target.value === "0" && setIncome("")}
                         onChange={(e) => setIncome(e.target.value)}
                       />
                     </div>
@@ -118,30 +119,30 @@ function BurkinaFasoUI({ country }) {
                   <p>
                     <label>Gross Pay:</label>
                   </p>
-                  <h4 id="gross-pay-value">{grossPay.toFixed(2)}</h4>
+                  <h4 id="gross-pay-value">{formatNumber(grossPay.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>Social Security-Employee (CNSS):</label>
                   </p>
-                  <h4 id="social-security-value">{socialSecurity.toFixed(2)}</h4>
+                  <h4 id="social-security-value">{formatNumber(socialSecurity.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>PAYE:</label>
                   </p>
-                  <h4 id="paye-value">{paye.toFixed(2)}</h4>
+                  <h4 id="paye-value">{formatNumber(paye.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>Net Pay:</label>
                   </p>
-                  <h4 id="net-pay-value">{netPay.toFixed(2)}</h4>
+                  <h4 id="net-pay-value">{formatNumber(netPay.toFixed(2))}</h4>
                 </div>
               </div>
             </div>
           </div>
-        </body>
+        </div>
       </div>
     );
 }

--- a/paye-calculator/src/UI/Burundi.js
+++ b/paye-calculator/src/UI/Burundi.js
@@ -61,7 +61,7 @@ const calculateSocialSecurity = (grossPay) => {
   
   return (
     <div>
-      <body>
+      <div>
         <div class="card">
           <div class="card-container">
             <div class="inputs-section">
@@ -84,11 +84,12 @@ const calculateSocialSecurity = (grossPay) => {
               <label>Gross Pay:</label>
               <div class="input">
               <input
-                type="number"
+                type="text"
                 name="gross_pay"
                 id="gross_pay"
                 value={income}
                 class="input"
+                onFocus={(e) => e.target.value === "0" && setIncome("")}
                 onChange={(e) => setIncome(e.target.value)}
               />
               </div>
@@ -136,7 +137,7 @@ const calculateSocialSecurity = (grossPay) => {
             </div>
           </div>
         </div>
-      </body>      
+      </div>      
     </div>
   );
 }

--- a/paye-calculator/src/UI/Cameroon.js
+++ b/paye-calculator/src/UI/Cameroon.js
@@ -51,7 +51,7 @@ function CameroonUI({ country }) {
 
   return (
     <div>
-      <body>
+      <div>
         <div class="card">
           <div class="card-container">
             <div class="inputs-section">
@@ -74,11 +74,12 @@ function CameroonUI({ country }) {
                   <label>Gross Pay:</label>
                   <div class="input">
                     <input
-                      type="number"
+                      type="text"
                       name="gross_pay"
                       id="gross_pay"
                       value={income}
                       class="input"
+                      onFocus={(e) => e.target.value === "0" && setIncome("")}
                       onChange={(e) => setIncome(e.target.value)}
                     />
                   </div>
@@ -137,7 +138,7 @@ function CameroonUI({ country }) {
             </div>
           </div>
         </div>
-      </body>
+      </div>
     </div>
   );
 }

--- a/paye-calculator/src/UI/CapeVerde.js
+++ b/paye-calculator/src/UI/CapeVerde.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-
+import { formatNumber } from "../utils";
 import getCurrency from "../lib/utils";
 
 function CapeVerdeUI({ country }) {
@@ -59,7 +59,7 @@ function CapeVerdeUI({ country }) {
   
     return (
       <div>
-        <body>
+        <div>
           <div class="card">
             <div class="card-container">
               <div class="inputs-section">
@@ -82,11 +82,12 @@ function CapeVerdeUI({ country }) {
                     <label for="gross_pay">Gross Pay:</label>
                     <div class="input">
                       <input
-                        type="number"
+                        type="text"
                         name="gross_pay"
                         id="gross_pay"
                         value={income}
                         class="input"
+                        onFocus={(e) => e.target.value === "0" && setIncome("")}
                         onChange={(e) => setIncome(e.target.value)}
                       />
                     </div>
@@ -116,30 +117,30 @@ function CapeVerdeUI({ country }) {
                   <p>
                     <label>Gross Pay:</label>
                   </p>
-                  <h4 id="gross-pay-value">{grossPay.toFixed(2)}</h4>
+                  <h4 id="gross-pay-value">{formatNumber(grossPay.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>Social Security-Employee (CNSS):</label>
                   </p>
-                  <h4 id="social-security-value">{socialSecurity.toFixed(2)}</h4>
+                  <h4 id="social-security-value">{formatNumber(socialSecurity.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>PAYE:</label>
                   </p>
-                  <h4 id="paye-value">{paye.toFixed(2)}</h4>
+                  <h4 id="paye-value">{formatNumber(paye.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>Net Pay:</label>
                   </p>
-                  <h4 id="net-pay-value">{netPay.toFixed(2)}</h4>
+                  <h4 id="net-pay-value">{formatNumber(netPay.toFixed(2))}</h4>
                 </div>
               </div>
             </div>
           </div>
-        </body>
+        </div>
       </div>
     );
 }

--- a/paye-calculator/src/UI/CentralAfrica.js
+++ b/paye-calculator/src/UI/CentralAfrica.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-
+import { formatNumber } from "../utils";
 import getCurrency from "../lib/utils";
 
 function CentralAfricaUI({ country }) {
@@ -60,7 +60,7 @@ function CentralAfricaUI({ country }) {
   
     return (
       <div>
-        <body>
+        <div>
           <div class="card">
             <div class="card-container">
               <div class="inputs-section">
@@ -83,11 +83,12 @@ function CentralAfricaUI({ country }) {
                     <label for="gross_pay">Gross Pay:</label>
                     <div class="input">
                       <input
-                        type="number"
+                        type="text"
                         name="gross_pay"
                         id="gross_pay"
                         value={income}
                         class="input"
+                        onFocus={(e) => e.target.value === "0" && setIncome("")}
                         onChange={(e) => setIncome(e.target.value)}
                       />
                     </div>
@@ -117,30 +118,30 @@ function CentralAfricaUI({ country }) {
                   <p>
                     <label>Gross Pay:</label>
                   </p>
-                  <h4 id="gross-pay-value">{grossPay.toFixed(2)}</h4>
+                  <h4 id="gross-pay-value">{formatNumber(grossPay.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>Social Security-Employee (CNSS):</label>
                   </p>
-                  <h4 id="social-security-value">{socialSecurity.toFixed(2)}</h4>
+                  <h4 id="social-security-value">{formatNumber(socialSecurity.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>PAYE:</label>
                   </p>
-                  <h4 id="paye-value">{paye.toFixed(2)}</h4>
+                  <h4 id="paye-value">{formatNumber(paye.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>Net Pay:</label>
                   </p>
-                  <h4 id="net-pay-value">{netPay.toFixed(2)}</h4>
+                  <h4 id="net-pay-value">{formatNumber(netPay.toFixed(2))}</h4>
                 </div>
               </div>
             </div>
           </div>
-        </body>
+        </div>
       </div>
     );
 }

--- a/paye-calculator/src/UI/Chad.js
+++ b/paye-calculator/src/UI/Chad.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-
+import { formatNumber } from "../utils";
 import getCurrency from "../lib/utils";
 
 function ChadUI({ country }) {
@@ -60,7 +60,7 @@ function ChadUI({ country }) {
   
     return (
       <div>
-        <body>
+        <div>
           <div class="card">
             <div class="card-container">
               <div class="inputs-section">
@@ -96,11 +96,12 @@ function ChadUI({ country }) {
                     <label for="gross_pay">Gross Pay:</label>
                     <div class="input">
                       <input
-                        type="number"
+                        type="text"
                         name="gross_pay"
                         id="gross_pay"
                         value={income}
                         class="input"
+                        onFocus={(e) => e.target.value === "0" && setIncome("")}
                         onChange={(e) => setIncome(e.target.value)}
                       />
                     </div>
@@ -130,36 +131,36 @@ function ChadUI({ country }) {
                   <p>
                     <label>Gross Pay:</label>
                   </p>
-                  <h4 id="gross-pay-value">{grossPay.toFixed(2)}</h4>
+                  <h4 id="gross-pay-value">{formatNumber(grossPay.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>Social Security-Employee (CNPS):</label>
                   </p>
-                  <h4 id="social-security-value">{socialSecurity.toFixed(2)}</h4>
+                  <h4 id="social-security-value">{formatNumber(socialSecurity.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>PAYE (Income Tax):</label>
                   </p>
-                  <h4 id="paye-value">{paye.toFixed(2)}</h4>
+                  <h4 id="paye-value">{formatNumber(paye.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>F.I.R (Rural Intervention Fund):</label>
                   </p>
-                  <h4 id="paye-value">{FIR.toFixed(2)}</h4>
+                  <h4 id="paye-value">{formatNumber(FIR.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>Net Pay:</label>
                   </p>
-                  <h4 id="net-pay-value">{netPay.toFixed(2)}</h4>
+                  <h4 id="net-pay-value">{formatNumber(netPay.toFixed(2))}</h4>
                 </div>
               </div>
             </div>
           </div>
-        </body>
+        </div>
       </div>
     );
 }

--- a/paye-calculator/src/UI/Comoros.js
+++ b/paye-calculator/src/UI/Comoros.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-
+import { formatNumber } from "../utils";
 import getCurrency from "../lib/utils";
 
 function ComorosUI({ country }) {
@@ -57,7 +57,7 @@ function ComorosUI({ country }) {
   
     return (
       <div>
-        <body>
+        <div>
           <div class="card">
             <div class="card-container">
               <div class="inputs-section">
@@ -80,11 +80,12 @@ function ComorosUI({ country }) {
                     <label for="gross_pay">Gross Pay:</label>
                     <div class="input">
                       <input
-                        type="number"
+                        type="text"
                         name="gross_pay"
                         id="gross_pay"
                         value={income}
                         class="input"
+                        onFocus={(e) => e.target.value === "0" && setIncome("")}
                         onChange={(e) => setIncome(e.target.value)}
                       />
                     </div>
@@ -114,24 +115,24 @@ function ComorosUI({ country }) {
                   <p>
                     <label>Gross Pay:</label>
                   </p>
-                  <h4 id="gross-pay-value">{grossPay.toFixed(2)}</h4>
+                  <h4 id="gross-pay-value">{formatNumber(grossPay.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>PAYE:</label>
                   </p>
-                  <h4 id="paye-value">{paye.toFixed(2)}</h4>
+                  <h4 id="paye-value">{formatNumber(paye.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>Net Pay:</label>
                   </p>
-                  <h4 id="net-pay-value">{netPay.toFixed(2)}</h4>
+                  <h4 id="net-pay-value">{formatNumber(netPay.toFixed(2))}</h4>
                 </div>
               </div>
             </div>
           </div>
-        </body>
+        </div>
       </div>
     );
 }

--- a/paye-calculator/src/UI/Congo.js
+++ b/paye-calculator/src/UI/Congo.js
@@ -52,7 +52,7 @@ function CongoUI({ country }) {
   
   return (
     <div>
-      <body>
+      <div>
         <div class="card">
           <div class="card-container">
             <div class="inputs-section">
@@ -75,11 +75,12 @@ function CongoUI({ country }) {
               <label>Gross Pay:</label>
               <div class="input">
               <input
-                type="number"
+                type="text"
                 name="gross_pay"
                 id="gross_pay"
                 value={income}
                 class="input"
+                onFocus={(e) => e.target.value === "0" && setIncome("")}
                 onChange={(e) => setIncome(e.target.value)}
               />
               </div>
@@ -123,7 +124,7 @@ function CongoUI({ country }) {
             </div>
           </div>
         </div>
-      </body>      
+      </div>      
     </div>
   );
 }

--- a/paye-calculator/src/UI/Djibouti.js
+++ b/paye-calculator/src/UI/Djibouti.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-
+import { formatNumber } from "../utils";
 import getCurrency from "../lib/utils";
 
 function DjiboutiUI({ country }) {
@@ -62,7 +62,7 @@ function DjiboutiUI({ country }) {
   
     return (
       <div>
-        <body>
+        <div>
           <div class="card">
             <div class="card-container">
               <div class="inputs-section">
@@ -85,11 +85,12 @@ function DjiboutiUI({ country }) {
                     <label for="gross_pay">Gross Pay:</label>
                     <div class="input">
                       <input
-                        type="number"
+                        type="text"
                         name="gross_pay"
                         id="gross_pay"
                         value={income}
                         class="input"
+                        onFocus={(e) => e.target.value === "0" && setIncome("")}
                         onChange={(e) => setIncome(e.target.value)}
                       />
                     </div>
@@ -119,30 +120,30 @@ function DjiboutiUI({ country }) {
                   <p>
                     <label>Gross Pay:</label>
                   </p>
-                  <h4 id="gross-pay-value">{grossPay.toFixed(2)}</h4>
+                  <h4 id="gross-pay-value">{formatNumber(grossPay.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>Social Security-Employee (CNSS):</label>
                   </p>
-                  <h4 id="social-security-value">{socialSecurity.toFixed(2)}</h4>
+                  <h4 id="social-security-value">{formatNumber(socialSecurity.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>PAYE:</label>
                   </p>
-                  <h4 id="paye-value">{paye.toFixed(2)}</h4>
+                  <h4 id="paye-value">{formatNumber(paye.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>Net Pay:</label>
                   </p>
-                  <h4 id="net-pay-value">{netPay.toFixed(2)}</h4>
+                  <h4 id="net-pay-value">{formatNumber(netPay.toFixed(2))}</h4>
                 </div>
               </div>
             </div>
           </div>
-        </body>
+        </div>
       </div>
     );
 }

--- a/paye-calculator/src/UI/Drc.js
+++ b/paye-calculator/src/UI/Drc.js
@@ -50,7 +50,7 @@ function DrcUI({ country }) {
   
   return (
     <div>
-      <body>
+      <div>
         <div class="card">
           <div class="card-container">
             <div class="inputs-section">
@@ -73,11 +73,12 @@ function DrcUI({ country }) {
               <label>Gross Pay:</label>
               <div class="input">
               <input
-                type="number"
+                type="text"
                 name="gross_pay"
                 id="gross_pay"
                 value={income}
                 class="input"
+                onFocus={(e) => e.target.value === "0" && setIncome("")}
                 onChange={(e) => setIncome(e.target.value)}
               />
               </div>
@@ -117,7 +118,7 @@ function DrcUI({ country }) {
             </div>
           </div>
         </div>
-      </body>      
+      </div>      
     </div>
   );
 }

--- a/paye-calculator/src/UI/Egypt.js
+++ b/paye-calculator/src/UI/Egypt.js
@@ -71,7 +71,7 @@ function EygptUI({ country }) {
   
   return (
     <div>
-      <body>
+      <div>
         <div class="card">
           <div class="card-container">
             <div class="inputs-section">
@@ -94,11 +94,12 @@ function EygptUI({ country }) {
               <label>Gross Pay:</label>
               <div class="input">
               <input
-                type="number"
+                type="text"
                 name="gross_pay"
                 id="gross_pay"
                 value={income}
                 class="input"
+                onFocus={(e) => e.target.value === "0" && setIncome("")}
                 onChange={(e) => setIncome(e.target.value)}
               />
               </div>
@@ -142,7 +143,7 @@ function EygptUI({ country }) {
             </div>
           </div>
         </div>
-      </body>      
+      </div>      
     </div>
   );
 }

--- a/paye-calculator/src/UI/EquatorialGuinea.js
+++ b/paye-calculator/src/UI/EquatorialGuinea.js
@@ -57,7 +57,7 @@ function EquatorialGuineaUI({ country }) {
 
   return (
     <div>
-      <body>
+      <div>
         <div class="card">
           <div class="card-container">
             <div class="inputs-section">
@@ -80,11 +80,12 @@ function EquatorialGuineaUI({ country }) {
                   <label>Gross Pay:</label>
                   <div class="input">
                     <input
-                      type="number"
+                      type="text"
                       name="gross_pay"
                       id="gross_pay"
                       value={income}
                       class="input"
+                      onFocus={(e) => e.target.value === "0" && setIncome("")}
                       onChange={(e) => setIncome(e.target.value)}
                     />
                   </div>
@@ -143,7 +144,7 @@ function EquatorialGuineaUI({ country }) {
             </div>
           </div>
         </div>
-      </body>
+      </div>
     </div>
   );
 }

--- a/paye-calculator/src/UI/Eritrea.js
+++ b/paye-calculator/src/UI/Eritrea.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-
+import { formatNumber } from "../utils";
 import getCurrency from "../lib/utils";
 
 /*
@@ -60,7 +60,7 @@ function EritreaUI({ country }) {
   
     return (
       <div>
-        <body>
+        <div>
           <div class="card">
             <div class="card-container">
               <div class="inputs-section">
@@ -83,11 +83,12 @@ function EritreaUI({ country }) {
                     <label for="gross_pay">Gross Pay:</label>
                     <div class="input">
                       <input
-                        type="number"
+                        type="text"
                         name="gross_pay"
                         id="gross_pay"
                         value={income}
                         class="input"
+                        onFocus={(e) => e.target.value === "0" && setIncome("")}
                         onChange={(e) => setIncome(e.target.value)}
                       />
                     </div>
@@ -117,24 +118,24 @@ function EritreaUI({ country }) {
                   <p>
                     <label>Gross Pay:</label>
                   </p>
-                  <h4 id="gross-pay-value">{grossPay.toFixed(2)}</h4>
+                  <h4 id="gross-pay-value">{formatNumber(grossPay.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>PAYE:</label>
                   </p>
-                  <h4 id="paye-value">{paye.toFixed(2)}</h4>
+                  <h4 id="paye-value">{formatNumber(paye.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>Net Pay:</label>
                   </p>
-                  <h4 id="net-pay-value">{netPay.toFixed(2)}</h4>
+                  <h4 id="net-pay-value">{formatNumber(netPay.toFixed(2))}</h4>
                 </div>
               </div>
             </div>
           </div>
-        </body>
+        </div>
       </div>
     );
 }

--- a/paye-calculator/src/UI/Ethiopia.js
+++ b/paye-calculator/src/UI/Ethiopia.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-
+import { formatNumber } from "../utils";
 import getCurrency from "../lib/utils";
 
 function EthiopiaUI({ country }) {
@@ -58,7 +58,7 @@ function EthiopiaUI({ country }) {
   
     return (
       <div>
-        <body>
+        <div>
           <div class="card">
             <div class="card-container">
               <div class="inputs-section">
@@ -81,11 +81,12 @@ function EthiopiaUI({ country }) {
                     <label for="gross_pay">Gross Pay:</label>
                     <div class="input">
                       <input
-                        type="number"
+                        type="text"
                         name="gross_pay"
                         id="gross_pay"
                         value={income}
                         class="input"
+                        onFocus={(e) => e.target.value === "0" && setIncome("")}
                         onChange={(e) => setIncome(e.target.value)}
                       />
                     </div>
@@ -115,30 +116,30 @@ function EthiopiaUI({ country }) {
                   <p>
                     <label>Gross Pay:</label>
                   </p>
-                  <h4 id="gross-pay-value">{grossPay.toFixed(2)}</h4>
+                  <h4 id="gross-pay-value">{formatNumber(grossPay.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>Social Security-Employee:</label>
                   </p>
-                  <h4 id="social-security-value">{socialSecurity.toFixed(2)}</h4>
+                  <h4 id="social-security-value">{formatNumber(socialSecurity.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>PAYE:</label>
                   </p>
-                  <h4 id="paye-value">{paye.toFixed(2)}</h4>
+                  <h4 id="paye-value">{formatNumber(paye.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>Net Pay:</label>
                   </p>
-                  <h4 id="net-pay-value">{netPay.toFixed(2)}</h4>
+                  <h4 id="net-pay-value">{formatNumber(netPay.toFixed(2))}</h4>
                 </div>
               </div>
             </div>
           </div>
-        </body>
+        </div>
       </div>
     );
 }

--- a/paye-calculator/src/UI/Gabon.js
+++ b/paye-calculator/src/UI/Gabon.js
@@ -114,7 +114,7 @@ function GabonUI({ country }) {
   
   return (
     <div>
-      <body>
+      <div>
         <div class="card">
           <div class="card-container">
             <div class="inputs-section">
@@ -137,11 +137,12 @@ function GabonUI({ country }) {
               <label>Gross Pay:</label>
               <div class="input">
               <input
-                type="number"
+                type="text"
                 name="gross_pay"
                 id="gross_pay"
                 value={income}
                 class="input"
+                onFocus={(e) => e.target.value === "0" && setIncome("")}
                 onChange={(e) => setIncome(e.target.value)}
               />
               </div>
@@ -226,7 +227,7 @@ function GabonUI({ country }) {
             </div>
           </div>
         </div>
-      </body>      
+      </div>      
     </div>
   );
 }

--- a/paye-calculator/src/UI/Gambia.js
+++ b/paye-calculator/src/UI/Gambia.js
@@ -66,7 +66,7 @@ function GambiaUI({ country }) {
   
   return (
     <div>
-      <body>
+      <div>
         <div class="card">
           <div class="card-container">
             <div class="inputs-section">
@@ -89,11 +89,12 @@ function GambiaUI({ country }) {
               <label>Gross Pay:</label>
               <div class="input">
               <input
-                type="number"
+                type="text"
                 name="gross_pay"
                 id="gross_pay"
                 value={income}
                 class="input"
+                onFocus={(e) => e.target.value === "0" && setIncome("")}
                 onChange={(e) => setIncome(e.target.value)}
               />
               </div>
@@ -147,7 +148,7 @@ function GambiaUI({ country }) {
             </div>
           </div>
         </div>
-      </body>      
+      </div>      
     </div>
   );
 }

--- a/paye-calculator/src/UI/Ghana.js
+++ b/paye-calculator/src/UI/Ghana.js
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import getCurrency from "../lib/utils";
+import { formatNumber } from "../utils";
 
 function GhanaUI({ country }) {
   const currency = getCurrency(country);
@@ -82,7 +83,7 @@ function GhanaUI({ country }) {
 
   return (
     <div>
-      <body>
+      <div>
         <div class="card">
           <div class="card-container">
             <div class="inputs-section">
@@ -105,11 +106,12 @@ function GhanaUI({ country }) {
                   <label for="gross_pay">Gross Pay:</label>
                   <div class="input">
                     <input
-                      type="number"
+                      type="text"
                       name="gross_pay"
                       id="gross_pay"
                       value={income}
                       class="input"
+                      onFocus={(e) => e.target.value === "0" && setIncome("")}
                       onChange={(e) => setIncome(e.target.value)}
                     />
                   </div>
@@ -154,30 +156,30 @@ function GhanaUI({ country }) {
                 <p>
                   <label>Gross Pay:</label>
                 </p>
-                <h4 id="gross-pay-value">{grossPay.toFixed(2)}</h4>
+                <h4 id="gross-pay-value">{formatNumber(grossPay.toFixed(2))}</h4>
               </div>
               <div class="gross-pay">
                 <p>
                   <label>Social Security-Employee (SSNIT):</label>
                 </p>
-                <h4 id="social-security-value">{socialSecurity.toFixed(2)}</h4>
+                <h4 id="social-security-value">{formatNumber(socialSecurity.toFixed(2))}</h4>
               </div>
               <div class="gross-pay">
                 <p>
                   <label>PAYE:</label>
                 </p>
-                <h4 id="paye-value">{paye.toFixed(2)}</h4>
+                <h4 id="paye-value">{formatNumber(paye.toFixed(2))}</h4>
               </div>
               <div class="gross-pay">
                 <p>
                   <label>Net Pay:</label>
                 </p>
-                <h4 id="net-pay-value">{netPay.toFixed(2)}</h4>
+                <h4 id="net-pay-value">{formatNumber(netPay.toFixed(2))}</h4>
               </div>
             </div>
           </div>
         </div>
-      </body>
+      </div>
     </div>
   );
 }

--- a/paye-calculator/src/UI/Guinea.js
+++ b/paye-calculator/src/UI/Guinea.js
@@ -55,7 +55,7 @@ function GuineaUI({ country }) {
 
   return (
     <div>
-      <body>
+      <div>
         <div class="card">
           <div class="card-container">
             <div class="inputs-section">
@@ -78,11 +78,12 @@ function GuineaUI({ country }) {
                   <label>Gross Pay:</label>
                   <div class="input">
                     <input
-                      type="number"
+                      type="text"
                       name="gross_pay"
                       id="gross_pay"
                       value={income}
                       class="input"
+                      onFocus={(e) => e.target.value === "0" && setIncome("")}
                       onChange={(e) => setIncome(e.target.value)}
                     />
                   </div>
@@ -135,7 +136,7 @@ function GuineaUI({ country }) {
             </div>
           </div>
         </div>
-      </body>
+      </div>
     </div>
   );
 }

--- a/paye-calculator/src/UI/GuineaBissau.js
+++ b/paye-calculator/src/UI/GuineaBissau.js
@@ -56,7 +56,7 @@ function GuineaBissauUI({ country }) {
   
   return (
     <div>
-      <body>
+      <div>
         <div class="card">
           <div class="card-container">
             <div class="inputs-section">
@@ -79,11 +79,12 @@ function GuineaBissauUI({ country }) {
               <label>Gross Pay:</label>
               <div class="input">
               <input
-                type="number"
+                type="text"
                 name="gross_pay"
                 id="gross_pay"
                 value={income}
                 class="input"
+                onFocus={(e) => e.target.value === "0" && setIncome("")}
                 onChange={(e) => setIncome(e.target.value)}
               />
               </div>
@@ -123,7 +124,7 @@ function GuineaBissauUI({ country }) {
             </div>
           </div>
         </div>
-      </body>      
+      </div>      
     </div>
   );
 }

--- a/paye-calculator/src/UI/IvoryCoast.js
+++ b/paye-calculator/src/UI/IvoryCoast.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-
+import { formatNumber } from "../utils";
 import getCurrency from "../lib/utils";
 
 function IvoryCoastUI({ country }) {
@@ -98,7 +98,7 @@ function IvoryCoastUI({ country }) {
   
     return (
       <div>
-        <body>
+        <div>
           <div class="card">
             <div class="card-container">
               <div class="inputs-section">
@@ -121,11 +121,12 @@ function IvoryCoastUI({ country }) {
                     <label for="gross_pay">Gross Pay:</label>
                     <div class="input">
                       <input
-                        type="number"
+                        type="text"
                         name="gross_pay"
                         id="gross_pay"
                         value={income}
                         class="input"
+                        onFocus={(e) => e.target.value === "0" && setIncome("")}
                         onChange={(e) => setIncome(e.target.value)}
                       />
                     </div>
@@ -155,42 +156,42 @@ function IvoryCoastUI({ country }) {
                   <p>
                     <label>Gross Pay:</label>
                   </p>
-                  <h4 id="gross-pay-value">{grossPay.toFixed(2)}</h4>
+                  <h4 id="gross-pay-value">{formatNumber(grossPay.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>Social Security-Employee (CNPS):</label>
                   </p>
-                  <h4 id="social-security-value">{socialSecurity.toFixed(2)}</h4>
+                  <h4 id="social-security-value">{formatNumber(socialSecurity.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>Salary Tax (IS):</label>
                   </p>
-                  <h4 id="paye-value">{salaryTax.toFixed(2)}</h4>
+                  <h4 id="paye-value">{formatNumber(salaryTax.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>National Contribution (CN):</label>
                   </p>
-                  <h4 id="paye-value">{CN.toFixed(2)}</h4>
+                  <h4 id="paye-value">{formatNumber(CN.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>Income Tax (IGR):</label>
                   </p>
-                  <h4 id="paye-value">{paye.toFixed(2)}</h4>
+                  <h4 id="paye-value">{formatNumber(paye.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>Net Pay:</label>
                   </p>
-                  <h4 id="net-pay-value">{netPay.toFixed(2)}</h4>
+                  <h4 id="net-pay-value">{formatNumber(netPay.toFixed(2))}</h4>
                 </div>
               </div>
             </div>
           </div>
-        </body>
+        </div>
       </div>
     );
 }

--- a/paye-calculator/src/UI/Kenya.js
+++ b/paye-calculator/src/UI/Kenya.js
@@ -109,7 +109,7 @@ const calculateNHIF = (grossPay) => {
   
   return (
     <div>
-      <body>
+      <div>
         <div class="card">
           <div class="card-container">
             <div class="inputs-section">
@@ -132,11 +132,12 @@ const calculateNHIF = (grossPay) => {
               <label>Gross Pay:</label>
               <div class="input">
               <input
-                type="number"
+                type="text"
                 name="gross_pay"
                 id="gross_pay"
                 value={income}
                 class="input"
+                onFocus={(e) => e.target.value === "0" && setIncome("")}
                 onChange={(e) => setIncome(e.target.value)}
               />
               </div>
@@ -204,7 +205,7 @@ const calculateNHIF = (grossPay) => {
             </div>
           </div>
         </div>
-      </body>      
+      </div>      
     </div>
   );
 }

--- a/paye-calculator/src/UI/Lesotho.js
+++ b/paye-calculator/src/UI/Lesotho.js
@@ -36,7 +36,7 @@ function LesothoUI({ country }) {
   
   return (
     <div>
-      <body>
+      <div>
         <div class="card">
           <div class="card-container">
             <div class="inputs-section">
@@ -59,11 +59,12 @@ function LesothoUI({ country }) {
               <label>Gross Pay:</label>
               <div class="input">
               <input
-                type="number"
+                type="text"
                 name="gross_pay"
                 id="gross_pay"
                 value={income}
                 class="input"
+                onFocus={(e) => e.target.value === "0" && setIncome("")}
                 onChange={(e) => setIncome(e.target.value)}
               />
               </div>
@@ -72,10 +73,11 @@ function LesothoUI({ country }) {
               <label>Other Deductions:</label>
               <div class="input">
               <input
-                type="number"
+                type="text"
                 name="deductions"
                 id="deductions"
                 value={deductions}
+                onFocus={(e) => e.target.value === "0" && setDeductions("")}
                 onChange={(e) => setDeductions(e.target.value)}
               />
               </div>
@@ -111,7 +113,7 @@ function LesothoUI({ country }) {
             </div>
           </div>
         </div>
-      </body>      
+      </div>      
     </div>
   );
 }

--- a/paye-calculator/src/UI/Liberia.js
+++ b/paye-calculator/src/UI/Liberia.js
@@ -47,7 +47,7 @@ function LiberiaUI({ country }) {
   
   return (
     <div>
-      <body>
+      <div>
         <div class="card">
           <div class="card-container">
             <div class="inputs-section">
@@ -70,11 +70,12 @@ function LiberiaUI({ country }) {
               <label>Gross Pay:</label>
               <div class="input">
               <input
-                type="number"
+                type="text"
                 name="gross_pay"
                 id="gross_pay"
                 value={income}
                 class="input"
+                onFocus={(e) => e.target.value === "0" && setIncome("")}
                 onChange={(e) => setIncome(e.target.value)}
               />
               </div>
@@ -114,7 +115,7 @@ function LiberiaUI({ country }) {
             </div>
           </div>
         </div>
-      </body>      
+      </div>      
     </div>
   );
 }

--- a/paye-calculator/src/UI/Libya.js
+++ b/paye-calculator/src/UI/Libya.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-
+import { formatNumber } from "../utils";
 import getCurrency from "../lib/utils";
 
 function LibyaUI({ country }) {
@@ -75,7 +75,7 @@ function LibyaUI({ country }) {
   
     return (
       <div>
-        <body>
+        <div>
           <div class="card">
             <div class="card-container">
               <div class="inputs-section">
@@ -98,11 +98,12 @@ function LibyaUI({ country }) {
                     <label for="gross_pay">Gross Pay:</label>
                     <div class="input">
                       <input
-                        type="number"
+                        type="text"
                         name="gross_pay"
                         id="gross_pay"
                         value={income}
                         class="input"
+                        onFocus={(e) => e.target.value === "0" && setIncome("")}
                         onChange={(e) => setIncome(e.target.value)}
                       />
                     </div>
@@ -132,42 +133,42 @@ function LibyaUI({ country }) {
                   <p>
                     <label>Gross Pay:</label>
                   </p>
-                  <h4 id="gross-pay-value">{grossPay.toFixed(2)}</h4>
+                  <h4 id="gross-pay-value">{formatNumber(grossPay.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>Social Security-Employee:</label>
                   </p>
-                  <h4 id="social-security-value">{socialSecurity.toFixed(2)}</h4>
+                  <h4 id="social-security-value">{formatNumber(socialSecurity.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>Social Unit Fund:</label>
                   </p>
-                  <h4 id="social-security-value">{socialUnity.toFixed(2)}</h4>
+                  <h4 id="social-security-value">{formatNumber(socialUnity.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>Income Tax:</label>
                   </p>
-                  <h4 id="paye-value">{paye.toFixed(2)}</h4>
+                  <h4 id="paye-value">{formatNumber(paye.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>Jehad Tax:</label>
                   </p>
-                  <h4 id="paye-value">{jehadTax.toFixed(2)}</h4>
+                  <h4 id="paye-value">{formatNumber(jehadTax.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>Net Pay:</label>
                   </p>
-                  <h4 id="net-pay-value">{netPay.toFixed(2)}</h4>
+                  <h4 id="net-pay-value">{formatNumber(netPay.toFixed(2))}</h4>
                 </div>
               </div>
             </div>
           </div>
-        </body>
+        </div>
       </div>
     );
 }

--- a/paye-calculator/src/UI/Madagascar.js
+++ b/paye-calculator/src/UI/Madagascar.js
@@ -54,7 +54,7 @@ function MadagscarUI({ country }) {
   
   return (
     <div>
-      <body>
+      <div>
         <div class="card">
           <div class="card-container">
             <div class="inputs-section">
@@ -77,11 +77,12 @@ function MadagscarUI({ country }) {
               <label>Gross Pay:</label>
               <div class="input">
               <input
-                type="number"
+                type="text"
                 name="gross_pay"
                 id="gross_pay"
                 value={income}
                 class="input"
+                onFocus={(e) => e.target.value === "0" && setIncome("")}
                 onChange={(e) => setIncome(e.target.value)}
               />
               </div>
@@ -125,7 +126,7 @@ function MadagscarUI({ country }) {
             </div>
           </div>
         </div>
-      </body>      
+      </div>      
     </div>
   );
 }

--- a/paye-calculator/src/UI/Malawi.js
+++ b/paye-calculator/src/UI/Malawi.js
@@ -44,7 +44,7 @@ function MalawiUI({ country }) {
   
   return (
     <div>
-      <body>
+      <div>
         <div class="card">
           <div class="card-container">
             <div class="inputs-section">
@@ -67,11 +67,12 @@ function MalawiUI({ country }) {
               <label>Gross Pay:</label>
               <div class="input">
               <input
-                type="number"
+                type="text"
                 name="gross_pay"
                 id="gross_pay"
                 value={income}
                 class="input"
+                onFocus={(e) => e.target.value === "0" && setIncome("")}
                 onChange={(e) => setIncome(e.target.value)}
               />
               </div>
@@ -111,7 +112,7 @@ function MalawiUI({ country }) {
             </div>
           </div>
         </div>
-      </body>      
+      </div>      
     </div>
   );
 }

--- a/paye-calculator/src/UI/Mali.js
+++ b/paye-calculator/src/UI/Mali.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-
+import { formatNumber } from "../utils";
 import getCurrency from "../lib/utils";
 
 function MaliUI({ country }) {
@@ -69,7 +69,7 @@ function MaliUI({ country }) {
   
     return (
       <div>
-        <body>
+        <div>
           <div class="card">
             <div class="card-container">
               <div class="inputs-section">
@@ -92,11 +92,12 @@ function MaliUI({ country }) {
                     <label for="gross_pay">Gross Pay:</label>
                     <div class="input">
                       <input
-                        type="number"
+                        type="text"
                         name="gross_pay"
                         id="gross_pay"
                         value={income}
                         class="input"
+                        onFocus={(e) => e.target.value === "0" && setIncome("")}
                         onChange={(e) => setIncome(e.target.value)}
                       />
                     </div>
@@ -126,36 +127,36 @@ function MaliUI({ country }) {
                   <p>
                     <label>Gross Pay:</label>
                   </p>
-                  <h4 id="gross-pay-value">{grossPay.toFixed(2)}</h4>
+                  <h4 id="gross-pay-value">{formatNumber(grossPay.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>Social Security-Employee:</label>
                   </p>
-                  <h4 id="social-security-value">{socialSecurity.toFixed(2)}</h4>
+                  <h4 id="social-security-value">{formatNumber(socialSecurity.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>National Health Insurance (NHIF):</label>
                   </p>
-                  <h4 id="social-security-value">{NHIF.toFixed(2)}</h4>
+                  <h4 id="social-security-value">{formatNumber(NHIF.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>PAYE:</label>
                   </p>
-                  <h4 id="paye-value">{paye.toFixed(2)}</h4>
+                  <h4 id="paye-value">{formatNumber(paye.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>Net Pay:</label>
                   </p>
-                  <h4 id="net-pay-value">{netPay.toFixed(2)}</h4>
+                  <h4 id="net-pay-value">{formatNumber(netPay.toFixed(2))}</h4>
                 </div>
               </div>
             </div>
           </div>
-        </body>
+        </div>
       </div>
     );
 }

--- a/paye-calculator/src/UI/Mauritania.js
+++ b/paye-calculator/src/UI/Mauritania.js
@@ -52,7 +52,7 @@ function MauritaniaUI({ country }) {
   
   return (
     <div>
-      <body>
+      <div>
         <div class="card">
           <div class="card-container">
             <div class="inputs-section">
@@ -75,11 +75,12 @@ function MauritaniaUI({ country }) {
               <label>Gross Pay:</label>
               <div class="input">
               <input
-                type="number"
+                type="text"
                 name="gross_pay"
                 id="gross_pay"
                 value={income}
                 class="input"
+                onFocus={(e) => e.target.value === "0" && setIncome("")}
                 onChange={(e) => setIncome(e.target.value)}
               />
               </div>
@@ -123,7 +124,7 @@ function MauritaniaUI({ country }) {
             </div>
           </div>
         </div>
-      </body>      
+      </div>      
     </div>
   );
 }

--- a/paye-calculator/src/UI/Mauritius.js
+++ b/paye-calculator/src/UI/Mauritius.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-
+import { formatNumber } from "../utils";
 import getCurrency from "../lib/utils";
 
 function MauritiusUI({ country }) {
@@ -88,7 +88,7 @@ function MauritiusUI({ country }) {
   
     return (
       <div>
-        <body>
+        <div>
           <div class="card">
             <div class="card-container">
               <div class="inputs-section">
@@ -111,11 +111,12 @@ function MauritiusUI({ country }) {
                     <label for="gross_pay">Gross Pay:</label>
                     <div class="input">
                       <input
-                        type="number"
+                        type="text"
                         name="gross_pay"
                         id="gross_pay"
                         value={income}
                         class="input"
+                        onFocus={(e) => e.target.value === "0" && setIncome("")}
                         onChange={(e) => setIncome(e.target.value)}
                       />
                     </div>
@@ -145,36 +146,36 @@ function MauritiusUI({ country }) {
                   <p>
                     <label>Gross Pay:</label>
                   </p>
-                  <h4 id="gross-pay-value">{grossPay.toFixed(2)}</h4>
+                  <h4 id="gross-pay-value">{formatNumber(grossPay.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>Social Security-Employee (CSG):</label>
                   </p>
-                  <h4 id="social-security-value">{socialSecurity.toFixed(2)}</h4>
+                  <h4 id="social-security-value">{formatNumber(socialSecurity.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>National Savings Fund (NSF):</label>
                   </p>
-                  <h4 id="social-security-value">{NSF.toFixed(2)}</h4>
+                  <h4 id="social-security-value">{formatNumber(NSF.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>PAYE:</label>
                   </p>
-                  <h4 id="paye-value">{paye.toFixed(2)}</h4>
+                  <h4 id="paye-value">{formatNumber(paye.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>Net Pay:</label>
                   </p>
-                  <h4 id="net-pay-value">{netPay.toFixed(2)}</h4>
+                  <h4 id="net-pay-value">{formatNumber(netPay.toFixed(2))}</h4>
                 </div>
               </div>
             </div>
           </div>
-        </body>
+        </div>
       </div>
     );
 }

--- a/paye-calculator/src/UI/Morocco.js
+++ b/paye-calculator/src/UI/Morocco.js
@@ -68,7 +68,7 @@ function MoroccoUI({ country }) {
 
   return (
     <div>
-      <body>
+      <div>
         <div class="card">
           <div class="card-container">
             <div class="inputs-section">
@@ -91,11 +91,12 @@ function MoroccoUI({ country }) {
                   <label>Gross Pay:</label>
                   <div class="input">
                     <input
-                      type="number"
+                      type="text"
                       name="gross_pay"
                       id="gross_pay"
                       value={income}
                       class="input"
+                      onFocus={(e) => e.target.value === "0" && setIncome("")}
                       onChange={(e) => setIncome(e.target.value)}
                     />
                   </div>
@@ -154,7 +155,7 @@ function MoroccoUI({ country }) {
             </div>
           </div>
         </div>
-      </body>
+      </div>
     </div>
   );
 }

--- a/paye-calculator/src/UI/Mozambique.js
+++ b/paye-calculator/src/UI/Mozambique.js
@@ -52,7 +52,7 @@ function MozambiqueUI({ country }) {
   
   return (
     <div>
-      <body>
+      <div>
         <div class="card">
           <div class="card-container">
             <div class="inputs-section">
@@ -75,11 +75,12 @@ function MozambiqueUI({ country }) {
               <label>Gross Pay:</label>
               <div class="input">
               <input
-                type="number"
+                type="text"
                 name="gross_pay"
                 id="gross_pay"
                 value={income}
                 class="input"
+                onFocus={(e) => e.target.value === "0" && setIncome("")}
                 onChange={(e) => setIncome(e.target.value)}
               />
               </div>
@@ -119,7 +120,7 @@ function MozambiqueUI({ country }) {
             </div>
           </div>
         </div>
-      </body>      
+      </div>      
     </div>
   );
 }

--- a/paye-calculator/src/UI/Namibia.js
+++ b/paye-calculator/src/UI/Namibia.js
@@ -53,7 +53,7 @@ function NamibiaUI({ country }) {
   
   return (
     <div>
-      <body>
+      <div>
         <div class="card">
           <div class="card-container">
             <div class="inputs-section">
@@ -76,11 +76,12 @@ function NamibiaUI({ country }) {
               <label>Gross Pay:</label>
               <div class="input">
               <input
-                type="number"
+                type="text"
                 name="gross_pay"
                 id="gross_pay"
                 value={income}
                 class="input"
+                onFocus={(e) => e.target.value === "0" && setIncome("")}
                 onChange={(e) => setIncome(e.target.value)}
               />
               </div>
@@ -120,7 +121,7 @@ function NamibiaUI({ country }) {
             </div>
           </div>
         </div>
-      </body>      
+      </div>      
     </div>
   );
 }

--- a/paye-calculator/src/UI/Niger.js
+++ b/paye-calculator/src/UI/Niger.js
@@ -67,7 +67,7 @@ function NigerUI({ country }) {
   
   return (
     <div>
-      <body>
+      <div>
         <div class="card">
           <div class="card-container">
             <div class="inputs-section">
@@ -90,11 +90,12 @@ function NigerUI({ country }) {
               <label>Gross Pay:</label>
               <div class="input">
               <input
-                type="number"
+                type="text"
                 name="gross_pay"
                 id="gross_pay"
                 value={income}
                 class="input"
+                onFocus={(e) => e.target.value === "0" && setIncome("")}
                 onChange={(e) => setIncome(e.target.value)}
               />
               </div>
@@ -134,7 +135,7 @@ function NigerUI({ country }) {
             </div>
           </div>
         </div>
-      </body>      
+      </div>      
     </div>
   );
 }

--- a/paye-calculator/src/UI/Nigeria.js
+++ b/paye-calculator/src/UI/Nigeria.js
@@ -109,7 +109,7 @@ const gross_relief = totalTaxableEarnings * 0.2
   
   return (
     <div>
-      <body>
+      <div>
         <div class="card">
           <div class="card-container">
             <div class="inputs-section">
@@ -132,11 +132,12 @@ const gross_relief = totalTaxableEarnings * 0.2
               <label>Gross Pay:</label>
               <div class="input">
               <input
-                type="number"
+                type="text"
                 name="gross_pay"
                 id="gross_pay"
                 value={income}
                 class="input"
+                onFocus={(e) => e.target.value === "0" && setIncome("")}
                 onChange={(e) => setIncome(e.target.value)}
               />
               </div>
@@ -145,11 +146,12 @@ const gross_relief = totalTaxableEarnings * 0.2
               <label>Transport Allowance:</label>
               <div class="input">
               <input
-                type="number"
+                type="text"
                 name="transport"
                 id="transport"
                 value={transportAllowance}
                 class="input"
+                onFocus={(e) => e.target.value === "0" && setTransportAllowance("")}
                 onChange={(e) => setTransportAllowance(e.target.value)}
               />
               </div>
@@ -159,11 +161,12 @@ const gross_relief = totalTaxableEarnings * 0.2
               <label>Housing Allowance:</label>
               <div class="input">
               <input
-                type="number"
+                type="text"
                 name="housing"
                 id="housing"
                 value={housingAllowance}
                 class="input"
+                onFocus={(e) => e.target.value === "0" && setHousingAllowance("")}
                 onChange={(e) => setHousingAllowance(e.target.value)}
               />
               </div>
@@ -173,11 +176,12 @@ const gross_relief = totalTaxableEarnings * 0.2
               <label>Other Allowances:</label>
               <div class="input">
               <input
-                type="number"
+                type="text"
                 name="housing"
                 id="housing"
                 value={housingAllowance}
                 class="input"
+                onFocus={(e) => e.target.value === "0" && setHousingAllowance("")}
                 onChange={(e) => setHousingAllowance(e.target.value)}
               />
               </div>
@@ -242,7 +246,7 @@ const gross_relief = totalTaxableEarnings * 0.2
             </div>
           </div>
         </div>
-      </body>      
+      </div>      
     </div>
   );
 }

--- a/paye-calculator/src/UI/Rwanda.js
+++ b/paye-calculator/src/UI/Rwanda.js
@@ -61,7 +61,7 @@ const calculateSocialSecurity = (grossPay) => {
   
   return (
     <div>
-      <body>
+      <div>
         <div class="card">
           <div class="card-container">
             <div class="inputs-section">
@@ -84,11 +84,12 @@ const calculateSocialSecurity = (grossPay) => {
               <label>Gross Pay:</label>
               <div class="input">
               <input
-                type="number"
+                type="text"
                 name="gross_pay"
-                id="gross_pay"
+                id="gross_pay" 
                 value={income}
                 class="input"
+                onFocus={(e) => e.target.value === "0" && setIncome("")}
                 onChange={(e) => setIncome(e.target.value)}
               />
               </div>
@@ -136,7 +137,7 @@ const calculateSocialSecurity = (grossPay) => {
             </div>
           </div>
         </div>
-      </body>      
+      </div>      
     </div>
   );
 }

--- a/paye-calculator/src/UI/SaoTome.js
+++ b/paye-calculator/src/UI/SaoTome.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-
+import { formatNumber } from "../utils";
 import getCurrency from "../lib/utils";
 
 function SaoTomeUI({ country }) {
@@ -62,7 +62,7 @@ function SaoTomeUI({ country }) {
   
     return (
       <div>
-        <body>
+        <div>
           <div class="card">
             <div class="card-container">
               <div class="inputs-section">
@@ -85,11 +85,12 @@ function SaoTomeUI({ country }) {
                     <label for="gross_pay">Gross Pay:</label>
                     <div class="input">
                       <input
-                        type="number"
+                        type="text"
                         name="gross_pay"
                         id="gross_pay"
                         value={income}
                         class="input"
+                        onFocus={(e) => e.target.value === "0" && setIncome("")}
                         onChange={(e) => setIncome(e.target.value)}
                       />
                     </div>
@@ -119,30 +120,30 @@ function SaoTomeUI({ country }) {
                   <p>
                     <label>Gross Pay:</label>
                   </p>
-                  <h4 id="gross-pay-value">{grossPay.toFixed(2)}</h4>
+                  <h4 id="gross-pay-value">{formatNumber(grossPay.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>Social Security-Employee (CNSS):</label>
                   </p>
-                  <h4 id="social-security-value">{socialSecurity.toFixed(2)}</h4>
+                  <h4 id="social-security-value">{formatNumber(socialSecurity.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>PAYE:</label>
                   </p>
-                  <h4 id="paye-value">{paye.toFixed(2)}</h4>
+                  <h4 id="paye-value">{formatNumber(paye.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>Net Pay:</label>
                   </p>
-                  <h4 id="net-pay-value">{netPay.toFixed(2)}</h4>
+                  <h4 id="net-pay-value">{formatNumber(netPay.toFixed(2))}</h4>
                 </div>
               </div>
             </div>
           </div>
-        </body>
+        </div>
       </div>
     );
 }

--- a/paye-calculator/src/UI/Senegal.js
+++ b/paye-calculator/src/UI/Senegal.js
@@ -66,7 +66,7 @@ function SenegalUI({ country }) {
   
   return (
     <div>
-      <body>
+      <div>
         <div class="card">
           <div class="card-container">
             <div class="inputs-section">
@@ -89,11 +89,12 @@ function SenegalUI({ country }) {
               <label>Gross Pay:</label>
               <div class="input">
               <input
-                type="number"
+                type="text"
                 name="gross_pay"
                 id="gross_pay"
                 value={income}
                 class="input"
+                onFocus={(e) => e.target.value === "0" && setIncome("")}
                 onChange={(e) => setIncome(e.target.value)}
               />
               </div>
@@ -141,7 +142,7 @@ function SenegalUI({ country }) {
             </div>
           </div>
         </div>
-      </body>      
+      </div>      
     </div>
   );
 }

--- a/paye-calculator/src/UI/Seychelles.js
+++ b/paye-calculator/src/UI/Seychelles.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-
+import { formatNumber } from "../utils";
 import getCurrency from "../lib/utils";
 
 function SeychellesUI({ country }) {
@@ -53,7 +53,7 @@ function SeychellesUI({ country }) {
   
     return (
       <div>
-        <body>
+        <div>
           <div class="card">
             <div class="card-container">
               <div class="inputs-section">
@@ -76,11 +76,12 @@ function SeychellesUI({ country }) {
                     <label for="gross_pay">Gross Pay:</label>
                     <div class="input">
                       <input
-                        type="number"
+                        type="text"
                         name="gross_pay"
                         id="gross_pay"
                         value={income}
                         class="input"
+                        onFocus={(e) => e.target.value === "0" && setIncome("")}
                         onChange={(e) => setIncome(e.target.value)}
                       />
                     </div>
@@ -110,30 +111,30 @@ function SeychellesUI({ country }) {
                   <p>
                     <label>Gross Pay:</label>
                   </p>
-                  <h4 id="gross-pay-value">{grossPay.toFixed(2)}</h4>
+                  <h4 id="gross-pay-value">{formatNumber(grossPay.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>Social Security-Employee (CNSS):</label>
                   </p>
-                  <h4 id="social-security-value">{socialSecurity.toFixed(2)}</h4>
+                  <h4 id="social-security-value">{formatNumber(socialSecurity.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>PAYE:</label>
                   </p>
-                  <h4 id="paye-value">{paye.toFixed(2)}</h4>
+                  <h4 id="paye-value">{formatNumber(paye.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>Net Pay:</label>
                   </p>
-                  <h4 id="net-pay-value">{netPay.toFixed(2)}</h4>
+                  <h4 id="net-pay-value">{formatNumber(netPay.toFixed(2))}</h4>
                 </div>
               </div>
             </div>
           </div>
-        </body>
+        </div>
       </div>
     );
 }

--- a/paye-calculator/src/UI/SierraLeone.js
+++ b/paye-calculator/src/UI/SierraLeone.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-
+import { formatNumber } from "../utils";
 import getCurrency from "../lib/utils";
 
 function SierraLeoneUI({ country }) {
@@ -57,7 +57,7 @@ function SierraLeoneUI({ country }) {
   
     return (
       <div>
-        <body>
+        <div>
           <div class="card">
             <div class="card-container">
               <div class="inputs-section">
@@ -80,11 +80,12 @@ function SierraLeoneUI({ country }) {
                     <label for="gross_pay">Gross Pay:</label>
                     <div class="input">
                       <input
-                        type="number"
+                        type="text"
                         name="gross_pay"
                         id="gross_pay"
                         value={income}
                         class="input"
+                        onFocus={(e) => e.target.value === "0" && setIncome("")}
                         onChange={(e) => setIncome(e.target.value)}
                       />
                     </div>
@@ -114,30 +115,30 @@ function SierraLeoneUI({ country }) {
                   <p>
                     <label>Gross Pay:</label>
                   </p>
-                  <h4 id="gross-pay-value">{grossPay.toFixed(2)}</h4>
+                  <h4 id="gross-pay-value">{formatNumber(grossPay.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>Social Security-Employee (NASSIT):</label>
                   </p>
-                  <h4 id="social-security-value">{socialSecurity.toFixed(2)}</h4>
+                  <h4 id="social-security-value">{formatNumber(socialSecurity.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>PAYE:</label>
                   </p>
-                  <h4 id="paye-value">{paye.toFixed(2)}</h4>
+                  <h4 id="paye-value">{formatNumber(paye.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>Net Pay:</label>
                   </p>
-                  <h4 id="net-pay-value">{netPay.toFixed(2)}</h4>
+                  <h4 id="net-pay-value">{formatNumber(netPay.toFixed(2))}</h4>
                 </div>
               </div>
             </div>
           </div>
-        </body>
+        </div>
       </div>
     );
 }

--- a/paye-calculator/src/UI/Somalia.js
+++ b/paye-calculator/src/UI/Somalia.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-
+import { formatNumber } from "../utils";
 import getCurrency from "../lib/utils";
 
 function SomaliaUI({ country }) {
@@ -49,7 +49,7 @@ function SomaliaUI({ country }) {
   
     return (
       <div>
-        <body>
+        <div>
           <div class="card">
             <div class="card-container">
               <div class="inputs-section">
@@ -72,11 +72,12 @@ function SomaliaUI({ country }) {
                     <label for="gross_pay">Gross Pay:</label>
                     <div class="input">
                       <input
-                        type="number"
+                        type="text"
                         name="gross_pay"
                         id="gross_pay"
                         value={income}
                         class="input"
+                        onFocus={(e) => e.target.value === "0" && setIncome("")}
                         onChange={(e) => setIncome(e.target.value)}
                       />
                     </div>
@@ -106,24 +107,24 @@ function SomaliaUI({ country }) {
                   <p>
                     <label>Gross Pay:</label>
                   </p>
-                  <h4 id="gross-pay-value">{grossPay.toFixed(2)}</h4>
+                  <h4 id="gross-pay-value">{formatNumber(grossPay.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>PAYE:</label>
                   </p>
-                  <h4 id="paye-value">{paye.toFixed(2)}</h4>
+                  <h4 id="paye-value">{formatNumber(paye.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>Net Pay:</label>
                   </p>
-                  <h4 id="net-pay-value">{netPay.toFixed(2)}</h4>
+                  <h4 id="net-pay-value">{formatNumber(netPay.toFixed(2))}</h4>
                 </div>
               </div>
             </div>
           </div>
-        </body>
+        </div>
       </div>
     );
 }

--- a/paye-calculator/src/UI/SouthAfrica.js
+++ b/paye-calculator/src/UI/SouthAfrica.js
@@ -67,7 +67,7 @@ function SouthAfricaUI({ country }) {
   
   return (
     <div>
-      <body>
+      <div>
         <div class="card">
           <div class="card-container">
             <div class="inputs-section">
@@ -90,11 +90,12 @@ function SouthAfricaUI({ country }) {
               <label>Gross Pay:</label>
               <div class="input">
               <input
-                type="number"
+                type="text"
                 name="gross_pay"
                 id="gross_pay"
                 value={income}
                 class="input"
+                onFocus={(e) => e.target.value === "0" && setIncome("")}
                 onChange={(e) => setIncome(e.target.value)}
               />
               </div>
@@ -102,23 +103,27 @@ function SouthAfricaUI({ country }) {
               <div class ="input-sec">
               <label>Age Group:</label>
               <div class="input">
-              <input type="number" name="age" id="age" value={age} onChange={(e) => setAge(e.target.value)} />
+              <input type="text" name="age" id="age" value={age} 
+              onFocus={(e) => e.target.value === "0" && setAge("")}
+              onChange={(e) => setAge(e.target.value)} />
               </div>
               </div>
               <div class ="input-sec">
               <label>UIF:</label>
               <div class="input">
-              <input type="number" name="uif" id="uif" defaultValue={uif} onChange={(e) => setUIF(e.target.value)} readOnly/>
+              <input type="number" name="uif" id="uif" defaultValue={uif} 
+              onChange={(e) => setUIF(e.target.value)} readOnly/>
               </div>
               </div>
               <div class ="input-sec">
               <label>Other Deductions:</label>
               <div class="input">
               <input
-                type="number"
+                type="text"
                 name="deductions"
                 id="deductions"
                 value={deductions}
+                onFocus={(e) => e.target.value === "0" && setDeductions("")}
                 onChange={(e) => setDeductions(e.target.value)}
               />
               </div>
@@ -158,7 +163,7 @@ function SouthAfricaUI({ country }) {
             </div>
           </div>
         </div>
-      </body>      
+      </div>      
     </div>
   );
 }

--- a/paye-calculator/src/UI/SouthSudan.js
+++ b/paye-calculator/src/UI/SouthSudan.js
@@ -50,7 +50,7 @@ function SouthSudanUI({ country }) {
   
   return (
     <div>
-      <body>
+      <div>
         <div class="card">
           <div class="card-container">
             <div class="inputs-section">
@@ -73,11 +73,12 @@ function SouthSudanUI({ country }) {
               <label>Gross Pay:</label>
               <div class="input">
               <input
-                type="number"
+                type="text"
                 name="gross_pay"
                 id="gross_pay"
                 value={income}
                 class="input"
+                onFocus={(e) => e.target.value === "0" && setIncome("")}
                 onChange={(e) => setIncome(e.target.value)}
               />
               </div>
@@ -117,7 +118,7 @@ function SouthSudanUI({ country }) {
             </div>
           </div>
         </div>
-      </body>      
+      </div>      
     </div>
   );
 }

--- a/paye-calculator/src/UI/Sudan.js
+++ b/paye-calculator/src/UI/Sudan.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-
+import { formatNumber } from "../utils";
 import getCurrency from "../lib/utils";
 
 function SudanUI({ country }) {
@@ -54,7 +54,7 @@ function SudanUI({ country }) {
   
     return (
       <div>
-        <body>
+        <div>
           <div class="card">
             <div class="card-container">
               <div class="inputs-section">
@@ -77,11 +77,12 @@ function SudanUI({ country }) {
                     <label for="gross_pay">Gross Pay:</label>
                     <div class="input">
                       <input
-                        type="number"
+                        type="text"
                         name="gross_pay"
                         id="gross_pay"
                         value={income}
                         class="input"
+                        onFocus={(e) => e.target.value === "0" && setIncome("")}
                         onChange={(e) => setIncome(e.target.value)}
                       />
                     </div>
@@ -111,30 +112,30 @@ function SudanUI({ country }) {
                   <p>
                     <label>Gross Pay:</label>
                   </p>
-                  <h4 id="gross-pay-value">{grossPay.toFixed(2)}</h4>
+                  <h4 id="gross-pay-value">{formatNumber(grossPay.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>Social Security-Employee (CNSS):</label>
                   </p>
-                  <h4 id="social-security-value">{socialSecurity.toFixed(2)}</h4>
+                  <h4 id="social-security-value">{formatNumber(socialSecurity.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>PAYE:</label>
                   </p>
-                  <h4 id="paye-value">{paye.toFixed(2)}</h4>
+                  <h4 id="paye-value">{formatNumber(paye.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>Net Pay:</label>
                   </p>
-                  <h4 id="net-pay-value">{netPay.toFixed(2)}</h4>
+                  <h4 id="net-pay-value">{formatNumber(netPay.toFixed(2))}</h4>
                 </div>
               </div>
             </div>
           </div>
-        </body>
+        </div>
       </div>
     );
 }

--- a/paye-calculator/src/UI/Swaziland.js
+++ b/paye-calculator/src/UI/Swaziland.js
@@ -70,7 +70,7 @@ function SwazilandUI({ country }) {
 
   return (
     <div>
-      <body>
+      <div>
         <div class="card">
           <div class="card-container">
             <div class="inputs-section">
@@ -93,11 +93,12 @@ function SwazilandUI({ country }) {
                   <label>Gross Pay:</label>
                   <div class="input">
                     <input
-                      type="number"
+                      type="text"
                       name="gross_pay"
                       id="gross_pay"
                       value={income}
                       class="input"
+                      onFocus={(e) => e.target.value === "0" && setIncome("")}
                       onChange={(e) => setIncome(e.target.value)}
                     />
                   </div>
@@ -106,10 +107,11 @@ function SwazilandUI({ country }) {
                   <label>Age Group:</label>
                   <div class="input">
                     <input
-                      type="number"
+                      type="text"
                       name="age"
                       id="age"
                       value={age}
+                      onFocus={(e) => e.target.value === "0" && setAge("")}
                       onChange={(e) => setAge(e.target.value)}
                     />
                   </div>
@@ -123,6 +125,7 @@ function SwazilandUI({ country }) {
                       id="uif"
                       defaultValue={npf}
                       onChange={(e) => setNPF(e.target.value)}
+                      readOnly
                     />
                   </div>
                 </div>
@@ -130,10 +133,11 @@ function SwazilandUI({ country }) {
                   <label>Other Deductions:</label>
                   <div class="input">
                     <input
-                      type="number"
+                      type="text"
                       name="deductions"
                       id="deductions"
                       value={deductions}
+                      onFocus={(e) => e.target.value === "0" && setDeductions("")}
                       onChange={(e) => setDeductions(e.target.value)}
                     />
                   </div>
@@ -188,7 +192,7 @@ function SwazilandUI({ country }) {
             </div>
           </div>
         </div>
-      </body>
+      </div>
     </div>
   );
 }

--- a/paye-calculator/src/UI/Tanzania.js
+++ b/paye-calculator/src/UI/Tanzania.js
@@ -49,7 +49,7 @@ function TanzaniaUI({ country }) {
   
   return (
     <div>
-      <body>
+      <div>
         <div class="card">
           <div class="card-container">
             <div class="inputs-section">
@@ -72,11 +72,12 @@ function TanzaniaUI({ country }) {
               <label>Gross Pay:</label>
               <div class="input">
               <input
-                type="number"
+                type="text"
                 name="gross_pay"
                 id="gross_pay"
                 value={income}
                 class="input"
+                onFocus={(e) => e.target.value === "0" && setIncome("")}
                 onChange={(e) => setIncome(e.target.value)}
               />
               </div>
@@ -116,7 +117,7 @@ function TanzaniaUI({ country }) {
             </div>
           </div>
         </div>
-      </body>      
+      </div>      
     </div>
   );
 }

--- a/paye-calculator/src/UI/Togo.js
+++ b/paye-calculator/src/UI/Togo.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-
+import { formatNumber } from "../utils";
 import getCurrency from "../lib/utils";
 
 function TogoUI({ country }) {
@@ -70,7 +70,7 @@ function TogoUI({ country }) {
   
     return (
       <div>
-        <body>
+        <div>
           <div class="card">
             <div class="card-container">
               <div class="inputs-section">
@@ -93,11 +93,12 @@ function TogoUI({ country }) {
                     <label for="gross_pay">Gross Pay:</label>
                     <div class="input">
                       <input
-                        type="number"
+                        type="text"
                         name="gross_pay"
                         id="gross_pay"
                         value={income}
                         class="input"
+                        onFocus={(e) => e.target.value === "0" && setIncome("")}
                         onChange={(e) => setIncome(e.target.value)}
                       />
                     </div>
@@ -127,36 +128,36 @@ function TogoUI({ country }) {
                   <p>
                     <label>Gross Pay:</label>
                   </p>
-                  <h4 id="gross-pay-value">{grossPay.toFixed(2)}</h4>
+                  <h4 id="gross-pay-value">{formatNumber(grossPay.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>Social Security-Employee (CNSS):</label>
                   </p>
-                  <h4 id="social-security-value">{socialSecurity.toFixed(2)}</h4>
+                  <h4 id="social-security-value">{formatNumber(socialSecurity.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>Standard Abatement:</label>
                   </p>
-                  <h4 id="social-security-value">{stdAbatement.toFixed(2)}</h4>
+                  <h4 id="social-security-value">{formatNumber(stdAbatement.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>PAYE:</label>
                   </p>
-                  <h4 id="paye-value">{paye.toFixed(2)}</h4>
+                  <h4 id="paye-value">{formatNumber(paye.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>Net Pay:</label>
                   </p>
-                  <h4 id="net-pay-value">{netPay.toFixed(2)}</h4>
+                  <h4 id="net-pay-value">{formatNumber(netPay.toFixed(2))}</h4>
                 </div>
               </div>
             </div>
           </div>
-        </body>
+        </div>
       </div>
     );
 }

--- a/paye-calculator/src/UI/Tunisia.js
+++ b/paye-calculator/src/UI/Tunisia.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-
+import { formatNumber } from "../utils";
 import getCurrency from "../lib/utils";
 
 function TunisiaUI({ country }) {
@@ -90,7 +90,7 @@ function TunisiaUI({ country }) {
   
     return (
       <div>
-        <body>
+        <div>
           <div class="card">
             <div class="card-container">
               <div class="inputs-section">
@@ -113,11 +113,12 @@ function TunisiaUI({ country }) {
                     <label for="gross_pay">Gross Pay:</label>
                     <div class="input">
                       <input
-                        type="number"
+                        type="text"
                         name="gross_pay"
                         id="gross_pay"
                         value={income}
                         class="input"
+                        onFocus={(e) => e.target.value === "0" && setIncome("")}
                         onChange={(e) => setIncome(e.target.value)}
                       />
                     </div>
@@ -147,36 +148,36 @@ function TunisiaUI({ country }) {
                   <p>
                     <label>Gross Pay:</label>
                   </p>
-                  <h4 id="gross-pay-value">{grossPay.toFixed(2)}</h4>
+                  <h4 id="gross-pay-value">{formatNumber(grossPay.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>Social Security-Employee (CNSS):</label>
                   </p>
-                  <h4 id="social-security-value">{socialSecurity.toFixed(2)}</h4>
+                  <h4 id="social-security-value">{formatNumber(socialSecurity.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>Social Solidarity Contribution (SSC): </label>
                   </p>
-                  <h4 id="social-security-value">{socialSolidarity.toFixed(2)}</h4>
+                  <h4 id="social-security-value">{formatNumber(socialSolidarity.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>IRPP - Tax:</label>
                   </p>
-                  <h4 id="paye-value">{paye.toFixed(2)}</h4>
+                  <h4 id="paye-value">{formatNumber(paye.toFixed(2))}</h4>
                 </div>
                 <div class="gross-pay">
                   <p>
                     <label>Net Pay:</label>
                   </p>
-                  <h4 id="net-pay-value">{netPay.toFixed(2)}</h4>
+                  <h4 id="net-pay-value">{formatNumber(netPay.toFixed(2))}</h4>
                 </div>
               </div>
             </div>
           </div>
-        </body>
+        </div>
       </div>
     );
 }

--- a/paye-calculator/src/UI/Uganda.js
+++ b/paye-calculator/src/UI/Uganda.js
@@ -89,7 +89,7 @@ function UgandaUI({ country }) {
   
   return (
     <div>
-      <body>
+      <div>
         <div class="card">
           <div class="card-container">
             <div class="inputs-section">
@@ -112,11 +112,12 @@ function UgandaUI({ country }) {
               <label>Gross Pay:</label>
               <div class="input">
               <input
-                type="number"
+                type="text"
                 name="gross_pay"
                 id="gross_pay"
                 value={income}
                 class="input"
+                onFocus={(e) => e.target.value === "0" && setIncome("")}
                 onChange={(e) => setIncome(e.target.value)}
               />
               </div>
@@ -173,7 +174,7 @@ function UgandaUI({ country }) {
             </div>
           </div>
         </div>
-      </body>      
+      </div>      
     </div>
   );
 }

--- a/paye-calculator/src/UI/Zambia.js
+++ b/paye-calculator/src/UI/Zambia.js
@@ -57,7 +57,7 @@ function ZambiaUI({ country }) {
   
   return (
     <div>
-      <body>
+      <div>
         <div class="card">
           <div class="card-container">
             <div class="inputs-section">
@@ -80,11 +80,12 @@ function ZambiaUI({ country }) {
               <label>Gross Pay:</label>
               <div class="input">
               <input
-                type="number"
+                type="text"
                 name="gross_pay"
                 id="gross_pay"
                 value={income}
                 class="input"
+                onFocus={(e) => e.target.value === "0" && setIncome("")}
                 onChange={(e) => setIncome(e.target.value)}
               />
               </div>
@@ -93,10 +94,11 @@ function ZambiaUI({ country }) {
               <label>Other Deductions:</label>
               <div class="input">
               <input
-                type="number"
+                type="text"
                 name="deductions"
                 id="deductions"
                 value={deductions}
+                onFocus={(e) => e.target.value === "0" && setDeductions("")}
                 onChange={(e) => setDeductions(e.target.value)}
               />
               </div>
@@ -140,7 +142,7 @@ function ZambiaUI({ country }) {
             </div>
           </div>
         </div>
-      </body>      
+      </div>      
     </div>
   );
 }

--- a/paye-calculator/src/UI/Zimbabwe.js
+++ b/paye-calculator/src/UI/Zimbabwe.js
@@ -56,7 +56,7 @@ function ZimbabweUI({ country }) {
   
   return (
     <div>
-      <body>
+      <div>
         <div class="card">
           <div class="card-container">
             <div class="inputs-section">
@@ -79,11 +79,12 @@ function ZimbabweUI({ country }) {
               <label>Gross Pay:</label>
               <div class="input">
               <input
-                type="number"
+                type="text"
                 name="gross_pay"
                 id="gross_pay"
                 value={income}
                 class="input"
+                onFocus={(e) => e.target.value === "0" && setIncome("")}
                 onChange={(e) => setIncome(e.target.value)}
               />
               </div>
@@ -127,7 +128,7 @@ function ZimbabweUI({ country }) {
             </div>
           </div>
         </div>
-      </body>      
+      </div>      
     </div>
   );
 }


### PR DESCRIPTION
This PR does the following:
- Add comma delimiting to the results, for easy readability
- Remove extra <body> tag in each country component that was creating extra whitespace
- Change inputs to text inputs, and remove trailing 0.